### PR TITLE
Fix: add RSS url configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 title: Kingbbode
 description: "개발 블로그"
 url: "//blog.kingbbode.com"
+rss_prefix: "blog.kingbbode.com"
 
 
 


### PR DESCRIPTION
Add: `rss_prefix: "blog.kingbbode.com"`

>  jekyll url configuration이 `//`로 시작되어서 RSS feed link가 깨집니다. site.url 자체를 수정하면 사이드이펙트가 있을것같아서 feed.xml과 _config.yml을 수정했습니다.