### PR TITLE
Fix: RSS url configuration

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -6,8 +6,8 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
+    <link>{{ site.rss_prefix }}{{ site.baseurl }}/</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.rss_prefix }}" rel="self" type="application/rss+xml" />
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
@@ -16,8 +16,8 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | strip_html | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.rss_prefix }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.rss_prefix }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}


### PR DESCRIPTION
Add: `rss_prefix: "blog.kingbbode.com"`

>  jekyll url configuration이 `//`로 시작되어서 RSS feed link가 깨집니다. site.url 자체를 수정하면 사이드이펙트가 있을것같아서 feed.xml과 _config.yml을 수정했습니다.